### PR TITLE
Fixed typo in doc tests

### DIFF
--- a/lib/elixir_math.ex
+++ b/lib/elixir_math.ex
@@ -356,11 +356,11 @@ defmodule ElixirMath do
 
   ## Examples
 
-      iex> ElixirMath.PrimeGenerator.is_prime(3)
+      iex> ElixirMath.is_prime(3)
       true
 
-       iex> ElixirMath.PrimeGenerator.is_prime(10)
-       false
+      iex> ElixirMath.is_prime(10)
+      false
 
   """
   def is_prime(x), do: PrimeGenerator.is_prime(x)


### PR DESCRIPTION
ElixirMath.is_prime/1 is a delegate method to ElixirMath.PrimeGenerator/1. The doc test in the ElixirMath module reflected using the ElixirMath.PrimeGenerator module, when in fact you can just use is_prime/1 within the ElixirMath module. I fixed this typo.